### PR TITLE
Extract rake-helpers module to file

### DIFF
--- a/lib/tasks/graphiti.rake
+++ b/lib/tasks/graphiti.rake
@@ -1,45 +1,7 @@
 namespace :graphiti do
-  module Graphiti
-    module Rails
-      module RakeHelpers
-        extend RescueRegistry::RailsTestHelpers
-
-        module_function
-
-        def session
-          @session ||= ActionDispatch::Integration::Session.new(::Rails.application)
-        end
-
-        def setup_rails!
-          ::Rails.application.eager_load!
-          ::Rails.application.config.cache_classes = true
-          ::Rails.application.config.action_controller.perform_caching = false
-        end
-
-        def make_request(path, debug = false)
-          if path.split("/").length == 2
-            path = "#{ApplicationResource.endpoint_namespace}#{path}"
-          end
-          path << if path.include?("?")
-            "&cache=bust"
-          else
-            "?cache=bust"
-          end
-          path = "#{path}&debug=true" if debug
-          handle_request_exceptions do
-            headers = {
-              "Authorization": ENV['AUTHORIZATION_HEADER']
-            }.compact
-            session.get(path.to_s, headers: headers)
-          end
-          JSON.parse(session.response.body)
-        end
-      end
-    end
-  end
-
   desc "Execute request without web server."
   task :request, [:path, :debug] => [:environment] do |_, args|
+    require_relative "rake_helpers"
     Graphiti::Rails::RakeHelpers.setup_rails!
     Graphiti.logger = Graphiti.stdout_logger
     Graphiti::Debugger.preserve = true
@@ -53,6 +15,7 @@ namespace :graphiti do
 
   desc "Execute benchmark without web server."
   task :benchmark, [:path, :requests] => [:environment] do |_, args|
+    require_relative "rake_helpers"
     Graphiti::Rails::RakeHelpers.setup_rails!
     took = Benchmark.ms {
       args[:requests].to_i.times do

--- a/lib/tasks/rake_helpers.rb
+++ b/lib/tasks/rake_helpers.rb
@@ -1,0 +1,34 @@
+module Graphiti::Rails::RakeHelpers
+  extend RescueRegistry::RailsTestHelpers
+
+  module_function
+
+  def session
+    @session ||= ActionDispatch::Integration::Session.new(::Rails.application)
+  end
+
+  def setup_rails!
+    ::Rails.application.eager_load!
+    ::Rails.application.config.cache_classes = true
+    ::Rails.application.config.action_controller.perform_caching = false
+  end
+
+  def make_request(path, debug = false)
+    if path.split("/").length == 2
+      path = "#{ApplicationResource.endpoint_namespace}#{path}"
+    end
+    path << if path.include?("?")
+      "&cache=bust"
+    else
+      "?cache=bust"
+    end
+    path = "#{path}&debug=true" if debug
+    handle_request_exceptions do
+      headers = {
+        "Authorization": ENV['AUTHORIZATION_HEADER']
+      }.compact
+      session.get(path.to_s, headers: headers)
+    end
+    JSON.parse(session.response.body)
+  end
+end


### PR DESCRIPTION
Per the discussion in https://github.com/graphiti-api/graphiti-rails/pull/91, here's a quick PR to pull the helpers into their own file.

This was the first half of the a bigger change that I'm PRing separately.