### PR TITLE
Rake helpers extended

### DIFF
--- a/lib/tasks/graphiti.rake
+++ b/lib/tasks/graphiti.rake
@@ -3,7 +3,7 @@ namespace :graphiti do
   task :request, [:path, :debug] => [:environment] do |_, args|
     require_relative "rake_helpers"
     extend Graphiti::Rails::RakeHelpers
-    setup_rails!
+
     Graphiti.logger = Graphiti.stdout_logger
     Graphiti::Debugger.preserve = true
     require "pp"
@@ -18,7 +18,7 @@ namespace :graphiti do
   task :benchmark, [:path, :requests] => [:environment] do |_, args|
     require_relative "rake_helpers"
     extend Graphiti::Rails::RakeHelpers
-    setup_rails!
+
     took = Benchmark.ms {
       args[:requests].to_i.times do
         make_request(args[:path])

--- a/lib/tasks/graphiti.rake
+++ b/lib/tasks/graphiti.rake
@@ -1,45 +1,7 @@
 namespace :graphiti do
-  module Graphiti
-    module Rails
-      module RakeHelpers
-        extend RescueRegistry::RailsTestHelpers
-
-        module_function
-
-        def session
-          @session ||= ActionDispatch::Integration::Session.new(::Rails.application)
-        end
-
-        def setup_rails!
-          ::Rails.application.eager_load!
-          ::Rails.application.config.cache_classes = true
-          ::Rails.application.config.action_controller.perform_caching = false
-        end
-
-        def make_request(path, debug = false)
-          if path.split("/").length == 2
-            path = "#{ApplicationResource.endpoint_namespace}#{path}"
-          end
-          path << if path.include?("?")
-            "&cache=bust"
-          else
-            "?cache=bust"
-          end
-          path = "#{path}&debug=true" if debug
-          handle_request_exceptions do
-            headers = {
-              "Authorization": ENV['AUTHORIZATION_HEADER']
-            }.compact
-            session.get(path.to_s, headers: headers)
-          end
-          JSON.parse(session.response.body)
-        end
-      end
-    end
-  end
-
   desc "Execute request without web server."
   task :request, [:path, :debug] => [:environment] do |_, args|
+    require_relative "rake_helpers"
     Graphiti::Rails::RakeHelpers.setup_rails!
     Graphiti.logger = Graphiti.stdout_logger
     Graphiti::Debugger.preserve = true
@@ -53,6 +15,7 @@ namespace :graphiti do
 
   desc "Execute benchmark without web server."
   task :benchmark, [:path, :requests] => [:environment] do |_, args|
+    require_relative "rake_helpers"
     Graphiti::Rails::RakeHelpers.setup_rails!
     took = Benchmark.ms {
       args[:requests].to_i.times do

--- a/lib/tasks/graphiti.rake
+++ b/lib/tasks/graphiti.rake
@@ -2,13 +2,14 @@ namespace :graphiti do
   desc "Execute request without web server."
   task :request, [:path, :debug] => [:environment] do |_, args|
     require_relative "rake_helpers"
-    Graphiti::Rails::RakeHelpers.setup_rails!
+    extend Graphiti::Rails::RakeHelpers
+    setup_rails!
     Graphiti.logger = Graphiti.stdout_logger
     Graphiti::Debugger.preserve = true
     require "pp"
     path, debug = args[:path], args[:debug]
     puts "Graphiti Request: #{path}"
-    json = Graphiti::Rails::RakeHelpers.make_request(path, debug)
+    json = make_request(path, debug)
     pp json
     Graphiti::Debugger.flush if debug
   end
@@ -16,10 +17,11 @@ namespace :graphiti do
   desc "Execute benchmark without web server."
   task :benchmark, [:path, :requests] => [:environment] do |_, args|
     require_relative "rake_helpers"
-    Graphiti::Rails::RakeHelpers.setup_rails!
+    extend Graphiti::Rails::RakeHelpers
+    setup_rails!
     took = Benchmark.ms {
       args[:requests].to_i.times do
-        Graphiti::Rails::RakeHelpers.make_request(args[:path])
+        make_request(args[:path])
       end
     }
     puts "Took: #{(took / args[:requests].to_f).round(2)}ms"

--- a/lib/tasks/rake_helpers.rb
+++ b/lib/tasks/rake_helpers.rb
@@ -1,6 +1,18 @@
 module Graphiti::Rails::RakeHelpers
   extend RescueRegistry::RailsTestHelpers
 
+  def self.included(klass)
+    klass.class_eval do
+      setup_rails!
+    end
+  end
+
+  def self.extended(other)
+    other.instance_eval do
+      setup_rails!
+    end
+  end
+
   module_function
 
   def session

--- a/lib/tasks/rake_helpers.rb
+++ b/lib/tasks/rake_helpers.rb
@@ -1,0 +1,34 @@
+module Graphiti::Rails::RakeHelpers
+  extend RescueRegistry::RailsTestHelpers
+
+  module_function
+
+  def session
+    @session ||= ActionDispatch::Integration::Session.new(::Rails.application)
+  end
+
+  def setup_rails!
+    ::Rails.application.eager_load!
+    ::Rails.application.config.cache_classes = true
+    ::Rails.application.config.action_controller.perform_caching = false
+  end
+
+  def make_request(path, debug = false)
+    if path.split("/").length == 2
+      path = "#{ApplicationResource.endpoint_namespace}#{path}"
+    end
+    path << if path.include?("?")
+      "&cache=bust"
+    else
+      "?cache=bust"
+    end
+    path = "#{path}&debug=true" if debug
+    handle_request_exceptions do
+      headers = {
+        "Authorization": ENV['AUTHORIZATION_HEADER']
+      }.compact
+      session.get(path.to_s, headers: headers)
+    end
+    JSON.parse(session.response.body)
+  end
+end


### PR DESCRIPTION
Followup to #1 (and https://github.com/graphiti-api/graphiti-rails/pull/91)

This alternative PR also extends the module in the task body. I'm curious of your use cases and opinions on if that's a good idea or not.

The downside is that `self` within the task (and thus the object being extended by the module), is still the main object. So in the strictest sense, this is still polluting the global namespace. However, the module is only extended when that particular task is run, so it does not affect the global namespace when _other_ tasks are run. Personally I find that a reasonable tradeoff in general (and for that reason, I typically suggest (to my teams) the pattern of using local modules in their own files, and required+included/extended in the task body.

But since this is for a library, and the module-function invocation of these helpers is sufficient, I could see erring on the side of caution instead and opting to stick with #1 instead of this.